### PR TITLE
Implement a "UnitStatCalculator" for dynamic unit stats

### DIFF
--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/Player.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/Player.java
@@ -101,6 +101,8 @@ public class Player {
     int[] researchStatus;
     int[] upgradeStatus;
 
+    private final UnitStatCalculator unitStatCalculator;
+
     Player(int id, String name, BW bw) {
 
         this.id = id;
@@ -108,6 +110,7 @@ public class Player {
         this.bw = bw;
         this.supplyTotalRace = new int[3];
         this.supplyUsedRace = new int[3];
+        this.unitStatCalculator = new UnitStatCalculator(this);
     }
 
     /**
@@ -625,119 +628,9 @@ public class Player {
         return this.textColor;
     }
 
-    /**
-     * Retrieves the maximum amount of energy that a unit type will have,
-     * taking the player's energy upgrades into consideration.
-     */
-    public int maxEnergy(UnitType unitType) {
-        int energy = unitType.maxEnergy();
-        if ((unitType == UnitType.Protoss_Arbiter       && getUpgradeLevel(UpgradeType.Khaydarin_Core)    > 0) ||
-                (unitType == UnitType.Protoss_Corsair       && getUpgradeLevel(UpgradeType.Argus_Jewel)       > 0) ||
-                (unitType == UnitType.Protoss_Dark_Archon   && getUpgradeLevel(UpgradeType.Argus_Talisman)    > 0) ||
-                (unitType == UnitType.Protoss_High_Templar  && getUpgradeLevel(UpgradeType.Khaydarin_Amulet)  > 0) ||
-                (unitType == UnitType.Terran_Ghost          && getUpgradeLevel(UpgradeType.Moebius_Reactor)   > 0) ||
-                (unitType == UnitType.Terran_Battlecruiser  && getUpgradeLevel(UpgradeType.Colossus_Reactor)  > 0) ||
-                (unitType == UnitType.Terran_Science_Vessel && getUpgradeLevel(UpgradeType.Titan_Reactor)     > 0) ||
-                (unitType == UnitType.Terran_Wraith         && getUpgradeLevel(UpgradeType.Apollo_Reactor)    > 0) ||
-                (unitType == UnitType.Terran_Medic          && getUpgradeLevel(UpgradeType.Caduceus_Reactor)  > 0) ||
-                (unitType == UnitType.Zerg_Defiler          && getUpgradeLevel(UpgradeType.Metasynaptic_Node) > 0) ||
-                (unitType == UnitType.Zerg_Queen            && getUpgradeLevel(UpgradeType.Gamete_Meiosis)    > 0) ) {
-            energy += 50;
-        }
-        return energy;
-    }
+    public UnitStatCalculator getUnitStatCalculator() {
 
-    /**
-     * Retrieves the top speed of a unit type, taking the player's speed
-     * upgrades into consideration.
-     */
-    public double topSpeed(UnitType unitType) {
-        double speed = unitType.topSpeed();
-        if ((unitType == UnitType.Terran_Vulture   && getUpgradeLevel(UpgradeType.Ion_Thrusters)        > 0) ||
-                (unitType == UnitType.Zerg_Overlord    && getUpgradeLevel(UpgradeType.Pneumatized_Carapace) > 0) ||
-                (unitType == UnitType.Zerg_Zergling    && getUpgradeLevel(UpgradeType.Metabolic_Boost)      > 0) ||
-                (unitType == UnitType.Zerg_Hydralisk   && getUpgradeLevel(UpgradeType.Muscular_Augments)    > 0) ||
-                (unitType == UnitType.Protoss_Zealot   && getUpgradeLevel(UpgradeType.Leg_Enhancements)     > 0) ||
-                (unitType == UnitType.Protoss_Shuttle  && getUpgradeLevel(UpgradeType.Gravitic_Drive)       > 0) ||
-                (unitType == UnitType.Protoss_Observer && getUpgradeLevel(UpgradeType.Gravitic_Boosters)    > 0) ||
-                (unitType == UnitType.Protoss_Scout    && getUpgradeLevel(UpgradeType.Gravitic_Thrusters)   > 0) ||
-                (unitType == UnitType.Zerg_Ultralisk   && getUpgradeLevel(UpgradeType.Anabolic_Synthesis)   > 0)) {
-            if ( unitType == UnitType.Protoss_Scout )
-                speed += 427.0/256.0;
-            else
-                speed = speed * 1.5;
-            if ( speed < 853.0/256.0 )
-                speed = 853.0/256.0;
-        }
-        return speed;
-    }
-
-    /**
-     * Retrieves the maximum weapon range of a weapon type, taking the player's weapon
-     * upgrades into consideration.
-     */
-    public int weaponMaxRange(WeaponType weaponType) {
-        int range = weaponType.maxRange();
-        if ( (weaponType == WeaponType.Gauss_Rifle   && getUpgradeLevel(UpgradeType.U_238_Shells)   > 0) ||
-                (weaponType == WeaponType.Needle_Spines && getUpgradeLevel(UpgradeType.Grooved_Spines) > 0) )
-            range += 1*32;
-        else if ( weaponType == WeaponType.Phase_Disruptor       && getUpgradeLevel(UpgradeType.Singularity_Charge) > 0 )
-            range += 2*32;
-        else if ( weaponType == WeaponType.Hellfire_Missile_Pack && getUpgradeLevel(UpgradeType.Charon_Boosters)    > 0 )
-            range += 3*32;
-        return range;
-    }
-
-    /**
-     * Retrieves the sight range of a unit type, taking the player's sight range
-     * upgrades into consideration.
-     */
-    public int sightRange(UnitType unitType) {
-        int range = unitType.sightRange();
-        if ((unitType == UnitType.Terran_Ghost     && getUpgradeLevel(UpgradeType.Ocular_Implants) > 0) ||
-                (unitType == UnitType.Zerg_Overlord    && getUpgradeLevel(UpgradeType.Antennae)        > 0) ||
-                (unitType == UnitType.Protoss_Observer && getUpgradeLevel(UpgradeType.Sensor_Array)    > 0) ||
-                (unitType == UnitType.Protoss_Scout    && getUpgradeLevel(UpgradeType.Apial_Sensors)   > 0))
-            range = 11*32;
-        return range;
-    }
-
-    /**
-     * Retrieves the weapon cooldown of a unit type, taking the player's attack speed
-     * upgrades into consideration.
-     */
-    public int weaponDamageCooldown(UnitType unitType) {
-        int cooldown = unitType.groundWeapon().damageCooldown();
-        if (unitType == UnitType.Zerg_Zergling && getUpgradeLevel(UpgradeType.Adrenal_Glands) > 0) {
-            // Divide cooldown by 2
-            cooldown /= 2;
-            // Prevent cooldown from going out of bounds
-            cooldown = Math.min(Math.max(cooldown,5), 250);
-        }
-        return cooldown;
-    }
-
-    /**
-     * Calculates the armor that a given unit type will have, including upgrades.
-     */
-    public int armor(UnitType unitType) {
-        int armor = unitType.armor();
-        armor += getUpgradeLevel(unitType.armorUpgrade());
-        if ( unitType == UnitType.Zerg_Ultralisk && getUpgradeLevel(UpgradeType.Chitinous_Plating) > 0 )
-            armor += 2;
-        else if ( unitType == UnitType.Hero_Torrasque )
-            armor += 2;
-        return armor;
-    }
-
-    /**
-     * Calculates the damage that a given weapon type can deal, including upgrades.
-     */
-    public int damage(WeaponType weaponType) {
-        int dmg = weaponType.damageAmount();
-        dmg += getUpgradeLevel(weaponType.upgradeType()) * weaponType.damageBonus();
-        dmg *= weaponType.damageFactor();
-        return dmg;
+        return this.unitStatCalculator;
     }
 
     /**

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/UnitStatCalculator.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/UnitStatCalculator.java
@@ -127,5 +127,4 @@ public class UnitStatCalculator {
         dmg *= weaponType.damageFactor();
         return dmg;
     }
-
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/UnitStatCalculator.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/UnitStatCalculator.java
@@ -1,0 +1,131 @@
+package org.openbw.bwapi4j;
+
+import org.openbw.bwapi4j.type.UnitType;
+import org.openbw.bwapi4j.type.UpgradeType;
+import org.openbw.bwapi4j.type.WeaponType;
+
+public class UnitStatCalculator {
+
+    final Player player;
+
+    /* default */ UnitStatCalculator(Player player) {
+
+        this.player = player;
+    }
+
+    /**
+     * Retrieves the maximum amount of energy that a unit type will have,
+     * taking the player's energy upgrades into consideration.
+     */
+    public int maxEnergy(UnitType unitType) {
+        int energy = unitType.maxEnergy();
+        if ((unitType == UnitType.Protoss_Arbiter       && this.player.getUpgradeLevel(UpgradeType.Khaydarin_Core)    > 0) ||
+                (unitType == UnitType.Protoss_Corsair       && this.player.getUpgradeLevel(UpgradeType.Argus_Jewel)       > 0) ||
+                (unitType == UnitType.Protoss_Dark_Archon   && this.player.getUpgradeLevel(UpgradeType.Argus_Talisman)    > 0) ||
+                (unitType == UnitType.Protoss_High_Templar  && this.player.getUpgradeLevel(UpgradeType.Khaydarin_Amulet)  > 0) ||
+                (unitType == UnitType.Terran_Ghost          && this.player.getUpgradeLevel(UpgradeType.Moebius_Reactor)   > 0) ||
+                (unitType == UnitType.Terran_Battlecruiser  && this.player.getUpgradeLevel(UpgradeType.Colossus_Reactor)  > 0) ||
+                (unitType == UnitType.Terran_Science_Vessel && this.player.getUpgradeLevel(UpgradeType.Titan_Reactor)     > 0) ||
+                (unitType == UnitType.Terran_Wraith         && this.player.getUpgradeLevel(UpgradeType.Apollo_Reactor)    > 0) ||
+                (unitType == UnitType.Terran_Medic          && this.player.getUpgradeLevel(UpgradeType.Caduceus_Reactor)  > 0) ||
+                (unitType == UnitType.Zerg_Defiler          && this.player.getUpgradeLevel(UpgradeType.Metasynaptic_Node) > 0) ||
+                (unitType == UnitType.Zerg_Queen            && this.player.getUpgradeLevel(UpgradeType.Gamete_Meiosis)    > 0) ) {
+            energy += 50;
+        }
+        return energy;
+    }
+
+    /**
+     * Retrieves the top speed of a unit type, taking the player's speed
+     * upgrades into consideration.
+     */
+    public double topSpeed(UnitType unitType) {
+        double speed = unitType.topSpeed();
+        if ((unitType == UnitType.Terran_Vulture   && this.player.getUpgradeLevel(UpgradeType.Ion_Thrusters)        > 0) ||
+                (unitType == UnitType.Zerg_Overlord    && this.player.getUpgradeLevel(UpgradeType.Pneumatized_Carapace) > 0) ||
+                (unitType == UnitType.Zerg_Zergling    && this.player.getUpgradeLevel(UpgradeType.Metabolic_Boost)      > 0) ||
+                (unitType == UnitType.Zerg_Hydralisk   && this.player.getUpgradeLevel(UpgradeType.Muscular_Augments)    > 0) ||
+                (unitType == UnitType.Protoss_Zealot   && this.player.getUpgradeLevel(UpgradeType.Leg_Enhancements)     > 0) ||
+                (unitType == UnitType.Protoss_Shuttle  && this.player.getUpgradeLevel(UpgradeType.Gravitic_Drive)       > 0) ||
+                (unitType == UnitType.Protoss_Observer && this.player.getUpgradeLevel(UpgradeType.Gravitic_Boosters)    > 0) ||
+                (unitType == UnitType.Protoss_Scout    && this.player.getUpgradeLevel(UpgradeType.Gravitic_Thrusters)   > 0) ||
+                (unitType == UnitType.Zerg_Ultralisk   && this.player.getUpgradeLevel(UpgradeType.Anabolic_Synthesis)   > 0)) {
+            if ( unitType == UnitType.Protoss_Scout )
+                speed += 427.0/256.0;
+            else
+                speed = speed * 1.5;
+            if ( speed < 853.0/256.0 )
+                speed = 853.0/256.0;
+        }
+        return speed;
+    }
+
+    /**
+     * Retrieves the maximum weapon range of a weapon type, taking the player's weapon
+     * upgrades into consideration.
+     */
+    public int weaponMaxRange(WeaponType weaponType) {
+        int range = weaponType.maxRange();
+        if ( (weaponType == WeaponType.Gauss_Rifle   && this.player.getUpgradeLevel(UpgradeType.U_238_Shells)   > 0) ||
+                (weaponType == WeaponType.Needle_Spines && this.player.getUpgradeLevel(UpgradeType.Grooved_Spines) > 0) )
+            range += 1*32;
+        else if ( weaponType == WeaponType.Phase_Disruptor       && this.player.getUpgradeLevel(UpgradeType.Singularity_Charge) > 0 )
+            range += 2*32;
+        else if ( weaponType == WeaponType.Hellfire_Missile_Pack && this.player.getUpgradeLevel(UpgradeType.Charon_Boosters)    > 0 )
+            range += 3*32;
+        return range;
+    }
+
+    /**
+     * Retrieves the sight range of a unit type, taking the player's sight range
+     * upgrades into consideration.
+     */
+    public int sightRange(UnitType unitType) {
+        int range = unitType.sightRange();
+        if ((unitType == UnitType.Terran_Ghost     && this.player.getUpgradeLevel(UpgradeType.Ocular_Implants) > 0) ||
+                (unitType == UnitType.Zerg_Overlord    && this.player.getUpgradeLevel(UpgradeType.Antennae)        > 0) ||
+                (unitType == UnitType.Protoss_Observer && this.player.getUpgradeLevel(UpgradeType.Sensor_Array)    > 0) ||
+                (unitType == UnitType.Protoss_Scout    && this.player.getUpgradeLevel(UpgradeType.Apial_Sensors)   > 0))
+            range = 11*32;
+        return range;
+    }
+
+    /**
+     * Retrieves the weapon cooldown of a unit type, taking the player's attack speed
+     * upgrades into consideration.
+     */
+    public int weaponDamageCooldown(UnitType unitType) {
+        int cooldown = unitType.groundWeapon().damageCooldown();
+        if (unitType == UnitType.Zerg_Zergling && this.player.getUpgradeLevel(UpgradeType.Adrenal_Glands) > 0) {
+            // Divide cooldown by 2
+            cooldown /= 2;
+            // Prevent cooldown from going out of bounds
+            cooldown = Math.min(Math.max(cooldown,5), 250);
+        }
+        return cooldown;
+    }
+
+    /**
+     * Calculates the armor that a given unit type will have, including upgrades.
+     */
+    public int armor(UnitType unitType) {
+        int armor = unitType.armor();
+        armor += this.player.getUpgradeLevel(unitType.armorUpgrade());
+        if ( unitType == UnitType.Zerg_Ultralisk && this.player.getUpgradeLevel(UpgradeType.Chitinous_Plating) > 0 )
+            armor += 2;
+        else if ( unitType == UnitType.Hero_Torrasque )
+            armor += 2;
+        return armor;
+    }
+
+    /**
+     * Calculates the damage that a given weapon type can deal, including upgrades.
+     */
+    public int damage(WeaponType weaponType) {
+        int dmg = weaponType.damageAmount();
+        dmg += this.player.getUpgradeLevel(weaponType.upgradeType()) * weaponType.damageBonus();
+        dmg *= weaponType.damageFactor();
+        return dmg;
+    }
+
+}

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Arbiter.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Arbiter.java
@@ -37,7 +37,13 @@ public class Arbiter extends MobileUnit implements Mechanical, SpellCaster, Arme
         
         return this.energy;
     }
-    
+
+    @Override
+    public int getMaxEnergy() {
+
+        return super.getMaxEnergy();
+    }
+
     public boolean stasisField(Position position) {
         
         if (this.energy < TechType.Stasis_Field.energyCost()) {
@@ -66,5 +72,41 @@ public class Arbiter extends MobileUnit implements Mechanical, SpellCaster, Arme
     @Override
     public Weapon getAirWeapon() {
         return airWeapon;
+    }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
     }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Archon.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Archon.java
@@ -18,4 +18,40 @@ public class Archon extends MobileUnit implements Armed {
     public Weapon getAirWeapon() {
         return airWeapon;
     }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Armed.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Armed.java
@@ -13,4 +13,12 @@ public interface Armed {
     Weapon getAirWeapon();
 
     Unit getTargetUnit();
+
+    int getGroundWeaponMaxRange();
+    int getGroundWeaponCooldown();
+    int getGroundWeaponDamage();
+
+    int getAirWeaponMaxRange();
+    int getAirWeaponCooldown();
+    int getAirWeaponDamage();
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/BattleCruiser.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/BattleCruiser.java
@@ -42,14 +42,57 @@ public class BattleCruiser extends MobileUnit implements Mechanical, SpellCaster
         return this.energy;
     }
 
+    @Override
+    public int getMaxEnergy() {
+
+        return super.getMaxEnergy();
+    }
 
     @Override
     public Weapon getGroundWeapon() {
+
         return groundWeapon;
     }
 
     @Override
     public Weapon getAirWeapon() {
+
         return airWeapon;
+    }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
     }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Broodling.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Broodling.java
@@ -18,4 +18,40 @@ public class Broodling extends MobileUnit implements Organic, Armed {
     public Weapon getAirWeapon() {
         return airWeapon;
     }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/ComsatStation.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/ComsatStation.java
@@ -28,4 +28,10 @@ public class ComsatStation extends Addon implements Mechanical, SpellCaster {
         
         return this.energy;
     }
+
+    @Override
+    public int getMaxEnergy() {
+
+        return super.getMaxEnergy();
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Corsair.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Corsair.java
@@ -36,7 +36,13 @@ public class Corsair extends MobileUnit implements Mechanical, SpellCaster, Arme
         
         return this.energy;
     }
-    
+
+    @Override
+    public int getMaxEnergy() {
+
+        return super.getMaxEnergy();
+    }
+
     public boolean disruptionWeb(Position position) {
         
         if (this.energy < TechType.Disruption_Web.energyCost()) {
@@ -57,5 +63,41 @@ public class Corsair extends MobileUnit implements Mechanical, SpellCaster, Arme
     @Override
     public Weapon getAirWeapon() {
         return airWeapon;
+    }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
     }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/DarkArchon.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/DarkArchon.java
@@ -37,7 +37,13 @@ public class DarkArchon extends MobileUnit implements Organic, SpellCaster {
         
         return this.energy;
     }
-    
+
+    @Override
+    public int getMaxEnergy() {
+
+        return super.getMaxEnergy();
+    }
+
     public boolean feedback(MobileUnit unit) {
         
         if (this.energy < TechType.Feedback.energyCost()) {

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Defiler.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Defiler.java
@@ -11,7 +11,7 @@ import org.openbw.bwapi4j.type.UnitType;
 import static org.openbw.bwapi4j.type.TechType.*;
 import static org.openbw.bwapi4j.type.UnitCommandType.*;
 
-public class Defiler extends MobileUnit implements Organic, SpellCaster, Burrowable, Armed {
+public class Defiler extends MobileUnit implements Organic, SpellCaster, Burrowable {
 
     private static final Logger logger = LogManager.getLogger();
 
@@ -44,7 +44,13 @@ public class Defiler extends MobileUnit implements Organic, SpellCaster, Burrowa
         
         return this.energy;
     }
-    
+
+    @Override
+    public int getMaxEnergy() {
+
+        return super.getMaxEnergy();
+    }
+
     /**
      * Consumes target Zerg mobile unit (except larva).
      * @param target Zerg unit (no larva)
@@ -99,15 +105,5 @@ public class Defiler extends MobileUnit implements Organic, SpellCaster, Burrowa
     @Override
     public boolean isBurrowed() {
         return this.burrowed;
-    }
-
-    @Override
-    public Weapon getGroundWeapon() {
-        return groundWeapon;
-    }
-
-    @Override
-    public Weapon getAirWeapon() {
-        return airWeapon;
     }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Devourer.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Devourer.java
@@ -18,4 +18,40 @@ public class Devourer extends MobileUnit implements Organic, Armed {
     public Weapon getAirWeapon() {
         return airWeapon;
     }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Dragoon.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Dragoon.java
@@ -18,4 +18,40 @@ public class Dragoon extends MobileUnit implements Mechanical, Armed {
     public Weapon getAirWeapon() {
         return airWeapon;
     }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Firebat.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Firebat.java
@@ -35,11 +35,49 @@ public class Firebat extends MobileUnit implements Organic, Armed {
 
     @Override
     public Weapon getGroundWeapon() {
+
         return groundWeapon;
     }
 
     @Override
     public Weapon getAirWeapon() {
+
         return airWeapon;
+    }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
     }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Ghost.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Ghost.java
@@ -41,6 +41,12 @@ public class Ghost extends MobileUnit implements SpellCaster, Organic, Armed {
         return this.energy;
     }
 
+    @Override
+    public int getMaxEnergy() {
+
+        return super.getMaxEnergy();
+    }
+
     public boolean personnelCloaking() {
         
         return issueCommand(this.id, Use_Tech, -1, -1, -1,
@@ -71,11 +77,49 @@ public class Ghost extends MobileUnit implements SpellCaster, Organic, Armed {
 
     @Override
     public Weapon getGroundWeapon() {
+
         return groundWeapon;
     }
 
     @Override
     public Weapon getAirWeapon() {
+
         return airWeapon;
+    }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
     }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Goliath.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Goliath.java
@@ -11,11 +11,49 @@ public class Goliath extends MobileUnit implements Mechanical, Armed {
 
     @Override
     public Weapon getGroundWeapon() {
+
         return groundWeapon;
     }
 
     @Override
     public Weapon getAirWeapon() {
+
         return airWeapon;
+    }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
     }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Guardian.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Guardian.java
@@ -18,4 +18,40 @@ public class Guardian extends MobileUnit implements Organic, Armed {
     public Weapon getAirWeapon() {
         return airWeapon;
     }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/HighTemplar.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/HighTemplar.java
@@ -36,7 +36,13 @@ public class HighTemplar extends MobileUnit implements Organic, SpellCaster {
         
         return this.energy;
     }
-    
+
+    @Override
+    public int getMaxEnergy() {
+
+        return super.getMaxEnergy();
+    }
+
     public boolean archonWarp() {
         
         // TODO how does this spell work? does the other templars ID have to be passed as well?

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Hydralisk.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Hydralisk.java
@@ -67,4 +67,40 @@ public class Hydralisk extends MobileUnit implements Organic, Burrowable, Armed,
     public Weapon getAirWeapon() {
         return airWeapon;
     }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/InfestedTerran.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/InfestedTerran.java
@@ -56,4 +56,40 @@ public class InfestedTerran extends MobileUnit implements Organic, Burrowable, A
     public Weapon getAirWeapon() {
         return airWeapon;
     }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Interceptor.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Interceptor.java
@@ -25,11 +25,49 @@ public class Interceptor extends MobileUnit implements Mechanical, Armed {
 
     @Override
     public Weapon getGroundWeapon() {
+
         return groundWeapon;
     }
 
     @Override
     public Weapon getAirWeapon() {
+
         return airWeapon;
+    }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
     }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Lurker.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Lurker.java
@@ -55,4 +55,40 @@ public class Lurker extends MobileUnit implements Organic, Burrowable, Armed {
     public Weapon getAirWeapon() {
         return airWeapon;
     }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Marine.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Marine.java
@@ -1,7 +1,5 @@
 package org.openbw.bwapi4j.unit;
 
-import org.openbw.bwapi4j.type.TechType;
-import org.openbw.bwapi4j.type.UnitCommandType;
 import org.openbw.bwapi4j.type.UnitType;
 
 import static org.openbw.bwapi4j.type.TechType.Stim_Packs;
@@ -35,11 +33,49 @@ public class Marine extends MobileUnit implements Organic, Armed {
 
     @Override
     public Weapon getGroundWeapon() {
+
         return groundWeapon;
     }
 
     @Override
     public Weapon getAirWeapon() {
+
         return airWeapon;
+    }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
     }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Medic.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Medic.java
@@ -53,4 +53,10 @@ public class Medic extends MobileUnit implements SpellCaster, Organic {
         
         return this.energy;
     }
+
+    @Override
+    public int getMaxEnergy() {
+
+        return super.getMaxEnergy();
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/MobileUnit.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/MobileUnit.java
@@ -237,4 +237,9 @@ public abstract class MobileUnit extends PlayerUnit {
 
         return this.isEnsnared;
     }
+
+    public double getTopSpeed() {
+
+        return getUnitStatCalculator().topSpeed(type);
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Mutalisk.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Mutalisk.java
@@ -37,4 +37,40 @@ public class Mutalisk extends MobileUnit implements Organic, Armed, Morphable {
     public Weapon getAirWeapon() {
         return airWeapon;
     }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/PhotonCannon.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/PhotonCannon.java
@@ -47,4 +47,40 @@ public class PhotonCannon extends Building implements Detector, Mechanical, Arme
     public int getMaxAirHits() {
         return this.type.maxAirHits();
     }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/PlayerUnit.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/PlayerUnit.java
@@ -192,8 +192,14 @@ public abstract class PlayerUnit extends Unit {
         return this.hitPoints;
     }
 
-    public int getArmor() {
-        return type.armor();
+    protected int getMaxEnergy() {
+
+        return getUnitStatCalculator().maxEnergy(type);
+    }
+
+    protected int getArmor() {
+
+        return getUnitStatCalculator().armor(type);
     }
 
     public int getShields() {
@@ -241,9 +247,9 @@ public abstract class PlayerUnit extends Unit {
         return this.lastKnownTilePosition;
     }
 
-    public int getSightRange() {
+    protected int getSightRange() {
         
-        return this.type.sightRange();
+        return getUnitStatCalculator().sightRange(type);
     }
 
     public boolean isDetector() {
@@ -266,6 +272,7 @@ public abstract class PlayerUnit extends Unit {
     }
 
     public boolean isInterruptible() {
+
         return isInterruptible;
     }
 
@@ -279,9 +286,9 @@ public abstract class PlayerUnit extends Unit {
         return this.type.tileHeight();
     }
 
-    public double topSpeed() {
+    protected double topSpeed() {
         
-        return this.type.topSpeed();
+        return getUnitStatCalculator().topSpeed(type);
     }
 
     public double getVelocityX() {
@@ -353,7 +360,39 @@ public abstract class PlayerUnit extends Unit {
         
         return this.isPowered;
     }
-    
+
+    protected int getGroundWeaponMaxRange() {
+
+        return getUnitStatCalculator().weaponMaxRange(type.groundWeapon());
+    }
+
+    protected int getGroundWeaponCooldown() {
+
+        // Only ground weapons have varied cooldowns.
+        return getUnitStatCalculator().weaponDamageCooldown(type);
+    }
+
+    protected int getGroundWeaponDamage() {
+
+        return getUnitStatCalculator().damage(type.groundWeapon());
+    }
+
+    protected int getAirWeaponMaxRange() {
+
+        return getUnitStatCalculator().weaponMaxRange(type.airWeapon());
+    }
+
+    protected int getAirWeaponCooldown() {
+
+        // Only ground weapons have varied cooldowns.
+        return type.airWeapon().damageCooldown();
+    }
+
+    protected int getAirWeaponDamage() {
+
+        return getUnitStatCalculator().damage(type.airWeapon());
+    }
+
     public int getDamageTo(PlayerUnit to) {
 
         return this.getDamageEvaluator().getDamageTo(to.initialType, this.initialType, to.getPlayer(), this.getPlayer());

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/PlayerUnit.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/PlayerUnit.java
@@ -197,7 +197,7 @@ public abstract class PlayerUnit extends Unit {
         return getUnitStatCalculator().maxEnergy(type);
     }
 
-    protected int getArmor() {
+    public int getArmor() {
 
         return getUnitStatCalculator().armor(type);
     }
@@ -247,7 +247,7 @@ public abstract class PlayerUnit extends Unit {
         return this.lastKnownTilePosition;
     }
 
-    protected int getSightRange() {
+    public int getSightRange() {
         
         return getUnitStatCalculator().sightRange(type);
     }
@@ -286,7 +286,7 @@ public abstract class PlayerUnit extends Unit {
         return this.type.tileHeight();
     }
 
-    protected double topSpeed() {
+    protected double getTopSpeed() {
         
         return getUnitStatCalculator().topSpeed(type);
     }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Queen.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Queen.java
@@ -40,7 +40,13 @@ public class Queen extends MobileUnit implements Organic, SpellCaster {
         
         return this.energy;
     }
-    
+
+    @Override
+    public int getMaxEnergy() {
+
+        return super.getMaxEnergy();
+    }
+
     /**
      * Infests a given Command Center.
      * @param commandCenter Command Center to be infested

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/ScienceVessel.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/ScienceVessel.java
@@ -55,4 +55,10 @@ public class ScienceVessel extends MobileUnit implements Mechanical, SpellCaster
         
         return this.energy;
     }
+
+    @Override
+    public int getMaxEnergy() {
+
+        return this.energy;
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Scourge.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Scourge.java
@@ -17,4 +17,40 @@ public class Scourge extends MobileUnit implements Organic, Armed {
     public Weapon getAirWeapon() {
         return airWeapon;
     }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Scout.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Scout.java
@@ -17,4 +17,40 @@ public class Scout extends MobileUnit implements Mechanical, Armed {
     public Weapon getAirWeapon() {
         return airWeapon;
     }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/SiegeTank.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/SiegeTank.java
@@ -47,4 +47,40 @@ public class SiegeTank extends MobileUnit implements Mechanical, Armed {
     public Weapon getAirWeapon() {
         return airWeapon;
     }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/SpellCaster.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/SpellCaster.java
@@ -6,4 +6,6 @@ package org.openbw.bwapi4j.unit;
 public interface SpellCaster {
 
     public int getEnergy();
+
+    public int getMaxEnergy();
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/SunkenColony.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/SunkenColony.java
@@ -43,4 +43,40 @@ public class SunkenColony extends Building implements Organic, Armed {
     public int getMaxGroundHits() {
         return this.type.maxGroundHits();
     }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Ultralisk.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Ultralisk.java
@@ -18,4 +18,40 @@ public class Ultralisk extends MobileUnit implements Organic, Armed {
     public Weapon getAirWeapon() {
         return airWeapon;
     }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Unit.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Unit.java
@@ -177,12 +177,15 @@ public abstract class Unit implements Comparable<Unit> {
     private BW bw;
     private int lastSpotted;
 
+    private final UnitStatCalculator unitStatCalculator;
+
     protected Unit(int id, UnitType unitType) {
 
         this.id = id;
         this.type = unitType;
         this.initialType = unitType;
         this.lastSpotted = 0;
+        this.unitStatCalculator = this.bw.getPlayer(id).getUnitStatCalculator();
     }
 
     final void setBW(BW bw) {
@@ -248,6 +251,11 @@ public abstract class Unit implements Comparable<Unit> {
     protected DamageEvaluator getDamageEvaluator() {
 
         return bw.getDamageEvaluator();
+    }
+
+    protected UnitStatCalculator getUnitStatCalculator() {
+
+        return this.unitStatCalculator;
     }
 
     protected Player getPlayer(int id) {

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Valkyrie.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Valkyrie.java
@@ -18,4 +18,40 @@ public class Valkyrie extends MobileUnit implements Mechanical, Armed {
     public Weapon getAirWeapon() {
         return airWeapon;
     }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Vulture.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Vulture.java
@@ -56,4 +56,40 @@ public class Vulture extends MobileUnit implements Mechanical, Armed {
     public Weapon getAirWeapon() {
         return airWeapon;
     }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Worker.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Worker.java
@@ -28,6 +28,7 @@ public abstract class Worker extends MobileUnit implements Armed {
         this.buildType = UnitType.None;
 
         super.initialize(unitData, index);
+
     }
 
     @Override
@@ -109,11 +110,49 @@ public abstract class Worker extends MobileUnit implements Armed {
 
     @Override
     public Weapon getGroundWeapon() {
+
         return groundWeapon;
     }
 
     @Override
     public Weapon getAirWeapon() {
+
         return airWeapon;
+    }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
     }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Wraith.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Wraith.java
@@ -23,13 +23,56 @@ public class Wraith extends MobileUnit implements Mechanical, Cloakable, Armed {
         return issueCommand(this.id, Decloak, -1, -1, -1, -1);
     }
 
+    public int getMaxEnergy() {
+
+        return super.getMaxEnergy();
+    }
+
     @Override
     public Weapon getGroundWeapon() {
+
         return groundWeapon;
     }
 
     @Override
     public Weapon getAirWeapon() {
+
         return airWeapon;
+    }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
     }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Zealot.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Zealot.java
@@ -18,4 +18,40 @@ public class Zealot extends MobileUnit implements Organic, Armed {
     public Weapon getAirWeapon() {
         return airWeapon;
     }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Zergling.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Zergling.java
@@ -56,4 +56,40 @@ public class Zergling extends MobileUnit implements Organic, Burrowable, Armed {
     public Weapon getAirWeapon() {
         return airWeapon;
     }
+
+    @Override
+    public int getGroundWeaponMaxRange() {
+
+        return super.getGroundWeaponMaxRange();
+    }
+
+    @Override
+    public int getGroundWeaponCooldown() {
+
+        return super.getGroundWeaponCooldown();
+    }
+
+    @Override
+    public int getGroundWeaponDamage() {
+
+        return super.getGroundWeaponDamage();
+    }
+
+    @Override
+    public int getAirWeaponMaxRange() {
+
+        return super.getAirWeaponMaxRange();
+    }
+
+    @Override
+    public int getAirWeaponCooldown() {
+
+        return super.getAirWeaponCooldown();
+    }
+
+    @Override
+    public int getAirWeaponDamage() {
+
+        return super.getAirWeaponDamage();
+    }
 }


### PR DESCRIPTION
From a continued discussion resulting from fixing Issue #25, it would be nice to also have the unit stats associated with the unit objects such that `dragoon.getGroundWeaponMaxRange()` is a possible call. The `UnitStatCalculator` might remain in the `Player` class such that `self.getGroundWeaponMaxRange(UnitType.Protoss_Dragoon)` is possible in the event the player does not have access to a `Dragoon` object.

In the spirit of the first release for BWAPI4J, I believe the `Armed` interface should be broken into `Attacker`, `GroundAttacker`, `AirAttacker` and then methods such as `getGroundWeapon`/`getAirWeapon` will need to be removed from units which do not have a ground/air weapon. In that case, some of these unit stats methods will also have to be removed. In addition, there are stat methods such as `getMaxGroundHits`/`getMaxAirHits` which may need to be added to the `Attacker` interfaces.