### PR TITLE
Clarify cooldown function names

### DIFF
--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/UnitStatCalculator.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/UnitStatCalculator.java
@@ -25,7 +25,6 @@ import org.openbw.bwapi4j.type.UpgradeType;
 import org.openbw.bwapi4j.type.WeaponType;
 import org.openbw.bwapi4j.unit.GroundAttacker;
 import org.openbw.bwapi4j.unit.Unit;
-import org.openbw.bwapi4j.unit.Zergling;
 
 public class UnitStatCalculator {
 

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/UnitStatCalculator.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/UnitStatCalculator.java
@@ -23,6 +23,9 @@ package org.openbw.bwapi4j;
 import org.openbw.bwapi4j.type.UnitType;
 import org.openbw.bwapi4j.type.UpgradeType;
 import org.openbw.bwapi4j.type.WeaponType;
+import org.openbw.bwapi4j.unit.GroundAttacker;
+import org.openbw.bwapi4j.unit.Unit;
+import org.openbw.bwapi4j.unit.Zergling;
 
 public class UnitStatCalculator {
 
@@ -111,10 +114,10 @@ public class UnitStatCalculator {
     }
 
     /**
-     * Retrieves the weapon cooldown of a unit type, taking the player's attack speed
+     * Retrieves the weapon max cooldown of a unit type, taking the player's attack speed
      * upgrades into consideration.
      */
-    public int weaponDamageCooldown(UnitType unitType) {
+    public int weaponDamageMaxCooldown(UnitType unitType) {
         int cooldown = unitType.groundWeapon().damageCooldown();
         if (unitType == UnitType.Zerg_Zergling && this.player.getUpgradeLevel(UpgradeType.Adrenal_Glands) > 0) {
             // Divide cooldown by 2
@@ -123,6 +126,14 @@ public class UnitStatCalculator {
             cooldown = Math.min(Math.max(cooldown,5), 250);
         }
         return cooldown;
+    }
+
+    /**
+     * Retrieves the weapon cooldown of a unit.
+     */
+    public int weaponDamageCooldown(Unit unit) {
+
+        return ((GroundAttacker)unit).getGroundWeapon().cooldown();
     }
 
     /**

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/PlayerUnit.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/PlayerUnit.java
@@ -428,10 +428,15 @@ public abstract class PlayerUnit extends Unit {
         return getUnitStatCalculator().weaponMaxRange(type.groundWeapon());
     }
 
+    protected int getGroundWeaponMaxCooldown() {
+
+        return getUnitStatCalculator().weaponDamageMaxCooldown(type);
+    }
+
     protected int getGroundWeaponCooldown() {
 
         // Only ground weapons have varied cooldowns.
-        return getUnitStatCalculator().weaponDamageCooldown(type);
+        return getUnitStatCalculator().weaponDamageCooldown(this);
     }
 
     protected int getGroundWeaponDamage() {


### PR DESCRIPTION
This pr fixes issue #43
* Changed current `weaponDamageCooldown` at `UnitStatCalculator` to `weaponDamageMaxCooldown`.
* Created new `weaponDamageCooldown` method at `UnitStatCalculator` that returns correct value for current unit´s weapon cooldown.
* Updated `PlayerUnit` to reflect this changes.
