### PR TITLE
Zerg ResourceDepots refactor/training functionality, MobileUnit build time, BWEM initalization

### DIFF
--- a/BWAPI4J/src/main/java/bwem/map/MapInitializerImpl.java
+++ b/BWAPI4J/src/main/java/bwem/map/MapInitializerImpl.java
@@ -155,7 +155,13 @@ public class MapInitializerImpl extends MapImpl implements MapInitializer {
       logger.info("Map::createBases: " + timer.elapsedMilliseconds() + " ms");
       timer.reset();
     }
-
+    
+    assignStartingLocationsToSuitableBases();
+    if (enableTimer) {
+        logger.info("Map::assignStartingLocationsToSuitableBases: " + timer.elapsedMilliseconds() + " ms");
+        timer.reset();
+      }
+    
     //    ///	bw << "Map::initialize: " << overallTimer.elapsedMilliseconds() << " ms" << endl;
     if (enableTimer) {
       logger.info("Map::initialize Total: " + overallTimer.elapsedMilliseconds() + " ms");

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/Player.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/Player.java
@@ -706,9 +706,14 @@ public class Player {
   }
 
   public boolean canMake(Unit builder, UnitType type) {
-    if (!canMake(type) || !builder.isA(type.whatBuilds().getFirst())) {
-      return false;
-    }
+	  if (!canMake(type) 
+			  || !(builder.isA(type.whatBuilds().getFirst()) 
+					 || (type.whatBuilds().getFirst().equals(UnitType.Zerg_Larva) 
+      						&& (builder.isA(UnitType.Zerg_Hatchery)
+      								|| builder.isA(UnitType.Zerg_Lair)
+      								|| builder.isA(UnitType.Zerg_Hive))))) {
+          return false;
+      }
     return type.requiredUnits()
         .stream()
         .filter(UnitType::isAddon)

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Hatchery.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Hatchery.java
@@ -5,7 +5,7 @@
 //    This file is part of BWAPI4J.
 //
 //    BWAPI4J is free software: you can redistribute it and/or modify
-//    it under the terms of the Lesser GNU General Public License as published
+//    it under the terms of the Lesser GNU General Public License as published 
 //    by the Free Software Foundation, version 3 only.
 //
 //    BWAPI4J is distributed in the hope that it will be useful,
@@ -20,117 +20,39 @@
 
 package org.openbw.bwapi4j.unit;
 
-import static org.openbw.bwapi4j.type.UnitCommandType.Morph;
-import static org.openbw.bwapi4j.type.UnitType.Zerg_Lair;
-
 import java.util.List;
 import java.util.stream.Collectors;
+
 import org.openbw.bwapi4j.type.TechType;
 import org.openbw.bwapi4j.type.UnitType;
 import org.openbw.bwapi4j.type.UpgradeType;
 
-public class Hatchery extends BuildingImpl
-    implements Organic, ResearchingFacility, ResourceDepot, Morphable {
-  protected Hatchery(int id, UnitType type, int timeSpotted) {
-    super(id, type, timeSpotted);
-  }
+import static org.openbw.bwapi4j.type.UnitCommandType.Morph;
+import static org.openbw.bwapi4j.type.UnitType.Zerg_Lair;
 
-  protected Hatchery(int id, int timeSpotted) {
-    this(id, UnitType.Zerg_Hatchery, timeSpotted);
-  }
+public class Hatchery extends ZergResourceDepotImpl {
 
-  @Override
-  public boolean isReadyForResources() {
-    return isCompleted;
-  }
-
-  @Override
-  public boolean trainWorker() {
-    return super.train(UnitType.Zerg_Drone);
-  }
-
-  /**
-   * Retrieves a list of larvae present at this hatchery.
-   *
-   * @return list of larvae
-   */
-  public List<Larva> getLarva() {
-    return super.getAllUnits()
-        .stream()
-        .filter(u -> u instanceof Larva && ((Larva) u).getHatchery().getId() == this.getId())
-        .map(u -> (Larva) u)
-        .collect(Collectors.toList());
-  }
-
-  public boolean researchBurrowing() {
-    return super.research(TechType.Burrowing);
-  }
-
-  @Override
-  public boolean isUpgrading() {
-    return isUpgrading;
-  }
-
-  @Override
-  public boolean isResearching() {
-    return isResearching;
-  }
-
-  @Override
-  public boolean cancelResearch() {
-    return super.cancelResearch();
-  }
-
-  @Override
-  public boolean cancelUpgrade() {
-    return super.cancelUpgrade();
-  }
-
-  @Override
-  public boolean morph(UnitType type) {
-    if (type != Zerg_Lair) {
-      throw new IllegalArgumentException("Cannot morph to " + type);
+    protected Hatchery(int id, UnitType type, int timeSpotted) {
+        
+        super(id, type, timeSpotted);
+    }
+    
+    protected Hatchery(int id, int timeSpotted) {
+        
+        this(id, UnitType.Zerg_Hatchery, timeSpotted);
     }
 
-    return issueCommand(this.id, Morph, -1, -1, -1, Zerg_Lair.getId());
-  }
+    @Override
+    public boolean morph(UnitType type) {
+        if (type != Zerg_Lair) {
+            throw new IllegalArgumentException("Cannot morph to " + type);
+        }
 
-  public boolean morph() {
-    return morph(Zerg_Lair);
-  }
-
-  @Override
-  public boolean canResearch(TechType techType) {
-    return super.canResearch(techType);
-  }
-
-  @Override
-  public boolean canUpgrade(UpgradeType upgradeType) {
-    return super.canUpgrade(upgradeType);
-  }
-
-  @Override
-  public boolean research(TechType techType) {
-    return super.research(techType);
-  }
-
-  @Override
-  public boolean upgrade(UpgradeType upgradeType) {
-    return super.upgrade(upgradeType);
-  }
-
-  @Override
-  public UpgradeInProgress getUpgradeInProgress() {
-    return super.getUpgradeInProgress();
-  }
-
-  @Override
-  public ResearchInProgress getResearchInProgress() {
-    return super.getResearchInProgress();
-  }
-
-  @Override
-  public int supplyProvided() {
-    return type.supplyProvided();
-  }
+        return issueCommand(this.id, Morph, -1, -1, -1, Zerg_Lair.getId());
+    }
+    
+    @Override
+    public boolean morph() {
+        return morph(Zerg_Lair);
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Hive.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Hive.java
@@ -5,7 +5,7 @@
 //    This file is part of BWAPI4J.
 //
 //    BWAPI4J is free software: you can redistribute it and/or modify
-//    it under the terms of the Lesser GNU General Public License as published
+//    it under the terms of the Lesser GNU General Public License as published 
 //    by the Free Software Foundation, version 3 only.
 //
 //    BWAPI4J is distributed in the hope that it will be useful,
@@ -22,13 +22,21 @@ package org.openbw.bwapi4j.unit;
 
 import org.openbw.bwapi4j.type.UnitType;
 
-public class Hive extends Lair {
-  protected Hive(int id, int timeSpotted) {
-    super(id, UnitType.Zerg_Hive, timeSpotted);
-  }
+public class Hive extends ZergResourceDepotImpl {
 
-  @Override
-  public boolean morph(UnitType type) {
-    return false;
-  }
+    protected Hive(int id, int timeSpotted) {
+        
+        super(id, UnitType.Zerg_Hive, timeSpotted);
+    }
+
+    @Override
+    public boolean morph(UnitType type) {
+        return false;
+    }
+
+	@Override
+	public boolean morph() {
+		// TODO Auto-generated method stub
+		return false;
+	}
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Lair.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Lair.java
@@ -5,7 +5,7 @@
 //    This file is part of BWAPI4J.
 //
 //    BWAPI4J is free software: you can redistribute it and/or modify
-//    it under the terms of the Lesser GNU General Public License as published
+//    it under the terms of the Lesser GNU General Public License as published 
 //    by the Free Software Foundation, version 3 only.
 //
 //    BWAPI4J is distributed in the hope that it will be useful,
@@ -20,48 +20,51 @@
 
 package org.openbw.bwapi4j.unit;
 
-import static org.openbw.bwapi4j.type.UnitCommandType.Morph;
-import static org.openbw.bwapi4j.type.UnitType.Zerg_Hive;
-
+import org.openbw.bwapi4j.type.UnitCommandType;
 import org.openbw.bwapi4j.type.UnitType;
 import org.openbw.bwapi4j.type.UpgradeType;
 
-public class Lair extends Hatchery {
-  protected Lair(int id, int timeSpotted) {
-    super(id, UnitType.Zerg_Lair, timeSpotted);
-  }
+import static org.openbw.bwapi4j.type.UnitCommandType.Morph;
+import static org.openbw.bwapi4j.type.UnitType.Zerg_Hive;
 
-  protected Lair(int id, UnitType type, int timeSpotted) {
-    super(id, type, timeSpotted);
-  }
+public class Lair extends ZergResourceDepotImpl {
 
-  @Override
-  public boolean isReadyForResources() {
-    return true;
-  }
+    protected Lair(int id, int timeSpotted) {
 
-  public boolean upgradeVentralSacs() {
-    return super.upgrade(UpgradeType.Ventral_Sacs);
-  }
-
-  public boolean upgradeAntennae() {
-    return super.upgrade(UpgradeType.Antennae);
-  }
-
-  public boolean upgradePneumatizedCarapace() {
-    return super.upgrade(UpgradeType.Pneumatized_Carapace);
-  }
-
-  @Override
-  public boolean morph(UnitType type) {
-    if (type != Zerg_Hive) {
-      throw new IllegalArgumentException("Cannot morph to " + type);
+        super(id, UnitType.Zerg_Lair, timeSpotted);
     }
-    return issueCommand(this.id, Morph, -1, -1, -1, Zerg_Hive.getId());
-  }
 
-  @Override
-  public boolean morph() {
-    return morph(Zerg_Hive);
-  }
+    protected Lair(int id, UnitType type, int timeSpotted) {
+
+        super(id, type, timeSpotted);
+    }
+
+
+    public boolean upgradeVentralSacs() {
+
+        return super.upgrade(UpgradeType.Ventral_Sacs);
+    }
+
+    public boolean upgradeAntennae() {
+
+        return super.upgrade(UpgradeType.Antennae);
+    }
+
+    public boolean upgradePneumatizedCarapace() {
+
+        return super.upgrade(UpgradeType.Pneumatized_Carapace);
+    }
+
+    @Override
+    public boolean morph(UnitType type) {
+        if (type != Zerg_Hive) {
+            throw new IllegalArgumentException("Cannot morph to " + type);
+        }
+        return issueCommand(this.id, Morph, -1, -1, -1, Zerg_Hive.getId());
+    }
+
+    @Override
+    public boolean morph() {
+        return morph(Zerg_Hive);
+    }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/MobileUnit.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/MobileUnit.java
@@ -72,4 +72,6 @@ public interface MobileUnit extends PlayerUnit {
   boolean isEnsnared();
 
   double getTopSpeed();
+  
+  int getRemainingTrainTime();
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/MobileUnitImpl.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/MobileUnitImpl.java
@@ -170,4 +170,8 @@ public abstract class MobileUnitImpl extends PlayerUnitImpl implements MobileUni
   public double getTopSpeed() {
     return getUnitStatCalculator().topSpeed(type);
   }
+  
+  public int getRemainingTrainTime() {
+	  return remainingTrainTime;
+  }
 }

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/ZergResourceDepotImpl.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/ZergResourceDepotImpl.java
@@ -1,0 +1,174 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//    Copyright (C) 2017-2018 OpenBW Team
+//
+//    This file is part of BWAPI4J.
+//
+//    BWAPI4J is free software: you can redistribute it and/or modify
+//    it under the terms of the Lesser GNU General Public License as published 
+//    by the Free Software Foundation, version 3 only.
+//
+//    BWAPI4J is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with BWAPI4J.  If not, see <http://www.gnu.org/licenses/>.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package org.openbw.bwapi4j.unit;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.openbw.bwapi4j.Position;
+import org.openbw.bwapi4j.type.TechType;
+import org.openbw.bwapi4j.type.UnitType;
+import org.openbw.bwapi4j.type.UpgradeType;
+import org.openbw.bwapi4j.unit.UnitImpl.TrainingSlot;
+
+public abstract class ZergResourceDepotImpl extends BuildingImpl implements Organic, ResourceDepot, ResearchingFacility, Morphable, TrainingFacility {
+
+	public ZergResourceDepotImpl(int id, UnitType unitType, int timeSpotted) {
+		
+		super(id, unitType, timeSpotted);
+	}
+	
+    @Override
+    public boolean isReadyForResources() {
+        return isCompleted;
+    }
+    
+    /**
+     * Retrieves a list of larvae present at this hatchery.
+     * @return list of larvae
+     */
+    public List<Larva> getLarva() {
+        return super.getAllUnits().stream()
+                .filter(u -> u instanceof Larva && ((Larva)u).getHatchery().getId() == this.getId())
+                .map(u -> (Larva)u).collect(Collectors.toList());
+    }
+	
+    @Override
+    public boolean trainWorker() {
+        return super.train(UnitType.Zerg_Drone);
+    }
+
+    @Override
+    public boolean isUpgrading() {
+        return isUpgrading;
+    }
+
+    @Override
+    public boolean isResearching() {
+        return isResearching;
+    }
+
+    @Override
+    public boolean cancelResearch() {
+        return super.cancelResearch();
+    }
+
+    @Override
+    public boolean cancelUpgrade() {
+        return super.cancelUpgrade();
+    }
+
+    @Override
+    public boolean canResearch(TechType techType) {
+        return super.canResearch(techType);
+    }
+
+    @Override
+    public boolean canUpgrade(UpgradeType upgradeType) {
+        return super.canUpgrade(upgradeType);
+    }
+
+    @Override
+    public boolean research(TechType techType) {
+        return super.research(techType);
+    }
+
+    @Override
+    public boolean upgrade(UpgradeType upgradeType) {
+        return super.upgrade(upgradeType);
+    }
+
+    @Override
+    public UpgradeInProgress getUpgradeInProgress() {
+        return super.getUpgradeInProgress();
+    }
+
+    @Override
+    public ResearchInProgress getResearchInProgress() {
+        return super.getResearchInProgress();
+    }
+	
+    @Override
+    public int supplyProvided() {
+        return type.supplyProvided();
+    }
+    
+    public boolean researchBurrowing() {
+        return super.research(TechType.Burrowing);
+    }
+    
+    @Override
+    public boolean cancelTrain(int slot) {
+        return super.cancelTrain(slot);
+    }
+
+    @Override
+    public boolean cancelTrain() {
+        return super.cancelTrain();
+    }
+    
+    @Override
+    public boolean canTrain(UnitType type) {
+        return UnitType.Zerg_Larva.equals(type.whatBuilds().getFirst())
+                && getPlayer(playerId).canMake(type);
+        //I feel that a check on whether there are any larva attached to this Hatchery would be appropriate, but there's no tracking for that and getLarva() is expensive
+    }
+    
+    //This returns the time until the next larva for Zerg! 
+    @Override
+    public int getRemainingTrainTime() {
+        return remainingTrainTime;
+    }
+
+    @Override
+    public List<TrainingSlot> getTrainingQueue() {
+        return trainingQueue;
+    }
+    
+    @Override
+    public int getTrainingQueueSize() {
+        return trainingQueueSize;
+    }
+    
+    @Override
+    public boolean isTraining() {
+        return isTraining;
+    }
+    
+    @Override
+    public boolean setRallyPoint(Position p) {
+        return super.setRallyPoint(p);
+    }
+
+    @Override
+    public boolean setRallyPoint(Unit target) {
+        return super.setRallyPoint(target);
+    }
+    
+    @Override
+    public boolean train(UnitType type) {
+        return super.train(type);
+    }
+    
+    public abstract boolean morph(UnitType type);
+    public abstract boolean morph();
+    
+}


### PR DESCRIPTION
Hatchery, Lair, and Hive now inherit from an abstract ZergResourceDepotImpl and can train units. (I know some people dislike exploding number of classes, but thankfully the game isn't going to change much so the scope for growth is limited). Player class canMake() returns true if checking a Hatchery can train something that morphs from a larva (Does not check amount of larva). 

MobileUnit can be queried for their remaining build time; returns "Number of frames remaining until the current training unit becomes completed, or the number of frames remaining until the next larva spawns."

BWEM now assigns starting locations as part of initialization 